### PR TITLE
fix: delete labels on server side

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -191,22 +191,6 @@ runs:
           -R "${GITHUB_REPOSITORY_OWNER}/${REPO}" \
           "$ARTIFACT_NAME" \
           --description "$GITHUB_REPOSITORY/${GITHUB_RUN_ID}"
-    # Sleep for a while
-    - if: steps.client1.outputs.changed_files != ''
-      shell: bash
-      run: sleep 1
-    # Delete a label
-    - if: steps.client1.outputs.changed_files != ''
-      shell: bash
-      env:
-        GH_TOKEN: ${{ steps.token.outputs.token }}
-        ARTIFACT_NAME: ${{ steps.client1.outputs.artifact_name }}
-        REPO: ${{inputs.server_repository}}
-      run: |
-        gh label delete \
-          -R "${GITHUB_REPOSITORY_OWNER}/${REPO}" \
-          --yes \
-          "$ARTIFACT_NAME"
     # Fail if changes are detected
     - if: steps.client1.outputs.changed_files != ''
       shell: bash

--- a/server/prepare/action.yaml
+++ b/server/prepare/action.yaml
@@ -27,6 +27,23 @@ inputs:
     description: |
       A file path to YAML config.
     required: false
+  label_name:
+    description: |
+      Label name to trigger the action.
+    required: false
+    default: ${{github.event.label.name}}
+  label_description:
+    description: |
+      Label description to trigger the action.
+      The format must be <repository owner>/<repository name>/<workflow run ID>.
+    required: false
+    default: ${{github.event.label.description}}
+  delete_label:
+    description: |
+      Either true or false. If true, the label is deleted.
+    required: false
+    default: "true"
+  
 outputs:
   pull_request:
     description: |
@@ -82,16 +99,49 @@ runs:
     - id: info
       shell: bash
       env:
-        LABEL_NAME: ${{github.event.label.name}}
-        # $GITHUB_REPOSITORY/${GITHUB_RUN_ID}
+        APP_ID: ${{inputs.app_id}}
+        APP_PRIVATE_KEY: ${{inputs.app_private_key}}
+        LABEL_NAME: ${{inputs.label_name}}
         LABEL_DESCRIPTION: ${{github.event.label.description}}
       run: |
-        repo_full_name=${LABEL_DESCRIPTION%/*}
+        if [ -z "$APP_ID" ]; then
+          echo "::error:: GitHub App ID is required"
+          exit 1
+        fi
+        if [ -z "$APP_PRIVATE_KEY" ]; then
+          echo "::error:: GitHub App Private Key is required"
+          exit 1
+        fi
+        if [ -z "$LABEL_NAME" ]; then
+          echo "::error:: Label name is required"
+          exit 1
+        fi
+        if [ -z "$LABEL_DESCRIPTION" ]; then
+          echo "::error:: Label description is required"
+          exit 1
+        fi
+        repo_full_name="${LABEL_DESCRIPTION%/*}"
+        repo="${repo_full_name#*/}"
+        run_id="${LABEL_DESCRIPTION##*/}"
+        if [ -z "$repo_full_name" ] || [ -z "$repo" ]; then
+          echo "::error:: Label description must be in the format <repository owner>/<repository name>/<workflow run ID>"
+          exit 1
+        fi
         {
           echo "repo_full_name=${repo_full_name}"
           echo "repo=${repo_full_name#*/}"
           echo "run_id=${LABEL_DESCRIPTION##*/}"
         } >> "$GITHUB_OUTPUT"
+
+    # Delete a label
+    # github.token requires issues:write permission
+    - shell: bash
+      if: inputs.delete_label == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        LABEL_NAME: ${{ inputs.label_name }}
+      run: |
+        gh label delete --yes "$LABEL_NAME" || :
 
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: permissions


### PR DESCRIPTION
## Why?

Now the client action deletes a label after 1 second.
This usually works well, but in case of GitHub Actions Self-hosted runner, sometimes the server workflow isn't triggered by label:created events.
So we decided to delete a label on the server side after the server workflow is triggered.

## ⚠️ `${{github.token}}` requires the `issues:write` permission on the server workflow

```yaml
permissions:
  issues: write
```