### PR TITLE
Fix a bug that labels can't be deleted

### DIFF
--- a/server/prepare/action.yaml
+++ b/server/prepare/action.yaml
@@ -141,7 +141,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         LABEL_NAME: ${{ inputs.label_name }}
       run: |
-        gh label delete --yes "$LABEL_NAME" || :
+        gh label delete -R "$GITHUB_REPOSITORY" --yes "$LABEL_NAME" || :
 
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: permissions


### PR DESCRIPTION
Fix a bug that labels can't be deleted.

```
Run gh label delete --yes "$LABEL_NAME" || :
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```