### PR TITLE
feat: default action input to client when server_repository is set

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,9 @@ description: Securefix Action
 inputs:
   # common
   action:
-    description: config
+    description: |
+      Action to run. One of "client", "validate-config", "prepare", "notify", "commit", "server".
+      If server_repository is set, defaults to "client".
     required: false
   app_id:
     description: |

--- a/src/run.ts
+++ b/src/run.ts
@@ -32,7 +32,10 @@ const deleteLabel = async (token: string, labelName: string) => {
 };
 
 export const main = async () => {
-  const action = core.getInput("action", { required: true });
+  const serverRepository = core.getInput("server_repository");
+  const action = serverRepository
+    ? core.getInput("action") || "client"
+    : core.getInput("action", { required: true });
   if (core.getState("post")) {
     if (action !== "prepare" && action !== "server") {
       return;


### PR DESCRIPTION
When server_repository is set, the action input now defaults to "client" instead of being required. This simplifies configuration for client usage.