### PR TITLE
fix: make PullRequest schema fields optional with defaults

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -29,12 +29,12 @@ export type AutomergeMethod = z.infer<typeof AutomergeMethod>;
 
 export const PullRequest = z.object({
   title: z.string(),
-  body: z.string(),
+  body: z.string().default(""),
   base: z.string(),
-  labels: z.string().array(),
-  assignees: z.string().array(),
-  reviewers: z.string().array(),
-  team_reviewers: z.string().array(),
+  labels: z.string().array().default([]),
+  assignees: z.string().array().default([]),
+  reviewers: z.string().array().default([]),
+  team_reviewers: z.string().array().default([]),
   draft: z.boolean(),
   automerge_method: AutomergeMethod.optional(),
   comment: z.string(),


### PR DESCRIPTION
Add .default([]) to reviewers, team_reviewers, labels, and assignees arrays, and .default("") to body field. This fixes validation errors when these optional fields are not provided in the input metadata.