### PR TITLE
chore(deps): drop undici override (no longer needed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,15 @@
         "undici": "^6.23.0"
       }
     },
+    "node_modules/@actions/github/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@actions/http-client": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
@@ -105,6 +114,15 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -2280,15 +2298,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
-      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "tmp": "^0.2.3",
     "zod": "^4.0.0"
   },
-  "overrides": {
-    "undici": "8.1.0"
-  },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Summary

Removes the `overrides.undici` entry from `package.json` and lets undici resolve naturally through the transitive dependency tree.

Diff vs `main`:

- `package.json`: removes the entire `overrides` block (only `undici: "8.1.0"` was left in it after #601 cleared the `@actions/artifact` chain).
- `package-lock.json`: replaces the single hoisted `undici@8.1.0` with two co-located `undici@6.25.0` entries under `node_modules/@actions/github/node_modules/undici` and `node_modules/@actions/http-client/node_modules/undici`. Net `+18 / -12`.

## Background

The override was introduced in #577 to escape a transitive `undici@5.29.0` (`< 6.24.0`) that suffered from a WebSocket DoS CVE (GHSA-v9p9-hfj2-hcw8) reported as Dependabot Alert #25. At the time the chain pinned undici to `^5.x`, where no patched version existed, so `overrides` was the only way out. It was later bumped to `8.0.2` (#578) and `8.1.0` (#584) as undici v8 became the maintained line.

## Why it's safe to drop now

Today both `@actions/http-client@3` (used by `@actions/github@9`) and `@actions/http-client@4` (used by `@actions/artifact@6`) declare `"undici": "^6.23.0"`. With the override removed, npm resolves undici to **6.25.0**, which is:

- Past the original `< 6.24.0` fix line for GHSA-v9p9-hfj2-hcw8 et al.
- Past the cap of every undici advisory currently published in the GitHub Advisory Database that affects the 6.x range (most cap at `< 6.24.0`; oldest 6.x cap is `< 6.21.2` for GHSA-cxrh-j4jr-qwg3).

`npm audit` reports 0 vulnerabilities after the change. `@fastify/busboy` (the v5-only sub-dep that #577 also got rid of) does not return.

If a new undici 6.x advisory appears in the future, Dependabot will surface it and we can either re-add the override or wait for `@actions/http-client` to bump its range. The override has done its job.

## Why not leave it as forward-looking insurance

`undici@8` and `undici@6` are not bug-for-bug identical, and forcing v8 onto callers that asked for `^6.23.0` is a behavioral mismatch that we don't actually need. Returning to natural resolution removes a divergence from upstream's tested combination without losing any current security posture.

## Test plan

- [x] `npm install` succeeds; `npm audit` reports 0 vulnerabilities.
- [x] `npm ls undici` shows only `6.25.0` (no `5.x`, no `8.x`, no "invalid" markers).
- [x] `npm run build` succeeds. `dist/` is gitignored and not part of this PR; the release pipeline rebuilds it.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)