### PR TITLE
chore: use takumi guard

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @jsr:registry=https://npm.jsr.io
+registry=https://npm.flatt.tech/

--- a/docs/validate-config.md
+++ b/docs/validate-config.md
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: csm-actions/securefix-action@latest


### PR DESCRIPTION
https://shisho.dev/docs/t/guard/quickstart/npm/

```console
$ npm install @panda-guard/test-malicious
npm error code E403
npm error 403 403 Forbidden - GET https://npm.flatt.tech/@panda-guard%2ftest-malicious - Package blocked by security policy
npm error 403 In most cases, you or one of your dependencies are requesting a package version that is forbidden by your security policy, or on a server you do not have access to.
npm error A complete log of this run can be found in: /Users/shunsukesuzuki/.npm/_logs/2026-06-05T00_43_44_406Z-debug-0.log
```