### PR TITLE
fix(deps): pin @azure/storage-blob to 12.31.0 to fix a broken bundle

### DIFF
--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -32,11 +32,12 @@ jobs:
       # npm test runs against src, and npm run build only checks that ncc can
       # produce a bundle. Neither runs dist/index.js, which is what workflows
       # actually execute, so a bundle that throws while it is being loaded
-      # passes both. Run it once to catch that.
-      - name: Smoke test dist/index.js
-        env:
-          INPUT_ACTION: validate-config
-          INPUT_CONFIG: |
+      # passes both. Run the action itself to catch that.
+      - name: Smoke test the action
+        uses: ./
+        with:
+          action: validate-config
+          config: |
             entries:
               - client:
                   repositories:
@@ -44,4 +45,3 @@ jobs:
                 push:
                   branches:
                     - main
-        run: node dist/index.js

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -29,3 +29,19 @@ jobs:
       - run: npm test
       - run: npm run typecheck
       - run: npm run build
+      # npm test runs against src, and npm run build only checks that ncc can
+      # produce a bundle. Neither runs dist/index.js, which is what workflows
+      # actually execute, so a bundle that throws while it is being loaded
+      # passes both. Run it once to catch that.
+      - name: Smoke test dist/index.js
+        env:
+          INPUT_ACTION: validate-config
+          INPUT_CONFIG: |
+            entries:
+              - client:
+                  repositories:
+                    - example/client
+                push:
+                  branches:
+                    - main
+        run: node dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,51 @@
         "unzip-stream": "^0.3.1"
       }
     },
+    "node_modules/@actions/artifact/node_modules/@azure/storage-blob": {
+      "version": "12.31.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+      "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.3.0",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@actions/artifact/node_modules/@azure/storage-common": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
+      "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@actions/core": {
       "version": "3.0.1",
       "resolved": "https://npm.flatt.tech/@actions/core/-/core-3.0.1.tgz",
@@ -270,51 +315,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@azure/storage-blob": {
-      "version": "12.33.0",
-      "resolved": "https://npm.flatt.tech/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
-      "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-client": "^1.9.3",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-lro": "^2.2.0",
-        "@azure/core-paging": "^1.6.2",
-        "@azure/core-rest-pipeline": "^1.19.1",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/core-xml": "^1.4.5",
-        "@azure/logger": "^1.1.4",
-        "@azure/storage-common": "^12.4.1",
-        "events": "^3.0.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@azure/storage-common": {
-      "version": "12.4.1",
-      "resolved": "https://npm.flatt.tech/@azure/storage-common/-/storage-common-12.4.1.tgz",
-      "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
-        "@azure/core-rest-pipeline": "^1.24.0",
-        "@azure/core-tracing": "^1.2.0",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.1.4",
-        "events": "^3.3.0",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "overrides": {
     "archiver-utils": {
       "glob": "$glob"
-    }
+    },
+    "@azure/storage-blob": "12.31.0",
+    "@azure/storage-common": "12.3.0"
   }
 }


### PR DESCRIPTION
## Problem

`dist/index.js` of `v0.6.1-0` and of the `latest` tag crashes at module load time, before any action code runs:

```
TypeError: crc64_require is not a function
    at dist/index.js:103891
```

Every action is affected — `client`, `server`, `prepare`, `commit`, `notify` and `validate-config` — because the failure happens while the bundle is being loaded. `v0.6.0` is not affected.

Reproduction:

```sh
git show v0.6.0:dist/index.js   > /tmp/v060.js
git show v0.6.1-0:dist/index.js > /tmp/v0610.js
INPUT_ACTION=validate-config INPUT_CONFIG_FILE=config.yaml node /tmp/v060.js   # OK
INPUT_ACTION=validate-config INPUT_CONFIG_FILE=config.yaml node /tmp/v0610.js  # TypeError
```

## Cause

`@azure/storage-common` 12.4.0 (pulled in via `@actions/artifact` -> `@azure/storage-blob`) added `dist/esm/crc64.js`. Its ESM compatibility block is not bundler-safe:

```js
import { createRequire } from "node:module";
let require;
let __filename;
if (__isNode__) {
  require = createRequire(import.meta.url);
  __filename = fileURLToPath(import.meta.url);
```

ncc (webpack) renames `require` to `crc64_require` and `__filename` to `crc64_filename`, and rewrites `import.meta.url` in terms of those very variables, so the generated code calls `crc64_require` before it is assigned:

```js
let crc64_require;
let crc64_filename;
if (__isNode__) {
  crc64_require = (0,external_node_module_namespaceObject.createRequire)(crc64_require("url").pathToFileURL(crc64_filename).href);
```

The CommonJS build (`dist/commonjs/crc64.js`) omits the block and is fine, but ncc resolves the `import` condition of the package exports and picks the ESM build.

`v0.6.0` resolved `@azure/storage-common` 12.3.0, which does not ship `crc64.js` at all, which is why it was not affected.

## Fix

Pin `@azure/storage-blob` and `@azure/storage-common` back to the versions `v0.6.0` shipped. `@actions/artifact` requires `@azure/storage-blob` `^12.30.0`, so 12.31.0 is in range. `@azure/storage-common` also has to be pinned, because `@azure/storage-blob` 12.31.0 depends on `^12.3.0`, which would resolve to 12.4.1 again.

This is a workaround. It should be reverted once the block is fixed upstream in azure-sdk-for-js; 12.4.1 is currently the newest release and still has it.

## Verification

Rebuilt `dist/index.js` locally and ran it against a real config:

```
$ INPUT_ACTION=validate-config INPUT_CONFIG_FILE=config.yaml node dist/index.js
::save-state name=post::true
$ echo $?
0
```

`npm run typecheck` and `npm test` (31 tests) pass.

## Why CI did not catch this

`npm test` runs vitest against `src`, and `npm run build` only checks that ncc can produce a bundle. Neither of them loads `dist/index.js`, which is what workflows actually execute, so a bundle whose generated code throws at load time passes the whole test job.

This PR adds a `uses: ./` step after the build. Local actions are resolved when the step runs, not when the job starts, so it picks up the bundle that was just built, and it goes through `action.yaml` exactly as a consumer does. `validate-config` is used because it needs no credentials and no network access. The step fails on the unpinned dependencies:

```
$ INPUT_ACTION=validate-config INPUT_CONFIG='entries: []' node <bundle built from main>
TypeError: crc64_require is not a function   # exit 1
$ INPUT_ACTION=validate-config INPUT_CONFIG='entries: []' node <bundle built from this branch>
::save-state name=post::true                 # exit 0
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)
