### PR TITLE
fix: adapt the test helpers to archiver v8

### DIFF
--- a/src/prepare_artifact.test.ts
+++ b/src/prepare_artifact.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import archiver from "archiver";
+import { ZipArchive } from "archiver";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 // The tests for prepare.downloadArtifact() are separated from prepare.test.ts
@@ -48,7 +48,7 @@ afterEach(() => {
 const createZip = async (): Promise<string> => {
   const zipPath = path.join(workDir, "artifact.zip");
   const output = fs.createWriteStream(zipPath);
-  const zip = archiver.create("zip", {});
+  const zip = new ZipArchive({});
   zip.pipe(output);
   zip.append("securefix-1_files.txt\n", {
     name: "securefix-1_files.txt",

--- a/src/unzip.test.ts
+++ b/src/unzip.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import archiver from "archiver";
+import { ZipArchive } from "archiver";
 import { describe, it, expect, beforeEach } from "vitest";
 import { extract, readFileModes } from "./unzip";
 
@@ -29,7 +29,7 @@ beforeEach(() => {
 const createZip = async (entries: Entry[]): Promise<string> => {
   const zipPath = path.join(workDir, "artifact.zip");
   const output = fs.createWriteStream(zipPath);
-  const zip = archiver.create("zip", {});
+  const zip = new ZipArchive({});
   zip.pipe(output);
   for (const entry of entries) {
     zip.append(entry.content ?? "", { name: entry.name, mode: entry.mode });


### PR DESCRIPTION
Fixes the CI failure on #765 so that archiver v8 can be merged.

archiver v8 switched to ESM (`"type": "module"`) and dropped the default export. It now exports only named classes:

```
keys: Archiver, JsonArchive, TarArchive, ZipArchive
default type: undefined
```

So `import archiver from "archiver"` binds `undefined` and `archiver.create("zip", {})` throws:

```
TypeError: Cannot read properties of undefined (reading 'create')
 ❯ createZip src/unzip.test.ts:32:24
```

The v7 factory call becomes a direct construction of the named export:

```diff
-import archiver from "archiver";
+import { ZipArchive } from "archiver";

-  const zip = archiver.create("zip", {});
+  const zip = new ZipArchive({});
```

`ZipArchive` extends the same `Archiver` core and sets `_format = "zip"`, so the resulting object and the `pipe` / `append` / `finalize` calls around it are unchanged.

Only the two test helpers use archiver — `src/unzip.test.ts` and `src/prepare_artifact.test.ts`. Nothing in the runtime path imports it, so the production unzip code is untouched.

Verified locally with archiver 8.0.0 installed: `npm run typecheck` is clean and `npm test` passes 45 tests across 6 files.

Base is the Renovate branch, so merging this puts the fix on #765.
