### PR TITLE
fix: grant id-token: write to the create-pr-branch caller

### DIFF
--- a/.github/workflows/create-pr-branch.yaml
+++ b/.github/workflows/create-pr-branch.yaml
@@ -18,6 +18,9 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      # wc-create-pr-branch.yaml requests id-token: write, and a called workflow
+      # can't be granted more than its caller has.
+      id-token: write
     with:
       version: pr/${{inputs.pr}}
       pr: ${{fromJSON(inputs.pr)}}


### PR DESCRIPTION
Dispatching Create Pull Request Branch fails at startup before any job runs:

https://github.com/csm-actions/securefix-action/actions/runs/34595108201

`wc-create-pr-branch.yaml` requests `id-token: write` for OIDC, but the calling job in `create-pr-branch.yaml` grants only `contents`, `pull-requests`, and `issues`. A called workflow can't be granted more than its caller has, so the run is rejected before it starts.

`csm-actions/update-branch-action` has the same pair of workflows and does grant `id-token: write`, which is why dispatching it there works.

Found while rebuilding `pr/793` to pick up a fix on `feat/aws-kms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)